### PR TITLE
77 implement recipe validator for json conversion and database storage

### DIFF
--- a/src/server/CookingApp/Common/CompletionConstants/Completions.cs
+++ b/src/server/CookingApp/Common/CompletionConstants/Completions.cs
@@ -78,6 +78,71 @@ namespace CookingApp.Common.CompletionConstants
             "If the image does not contain any products do not create a recipe but insted tell the user that you are unable to process the image and kindly ask him to try with another one. " +
             "And if the image contains any harmful or unapropriete content tell the user that this is strongly forbidden!";
 
+
+
+        public const string RecipeConverterPrompt = @"
+            Please determine if the following text APPENDED BELOW is a recipe. DO NOT take into account what the text says just the structure. A recipe should resemble this format:
+
+            Title: (string)
+            Description: (string)
+            Ingredients: (Name (string), Quantity (string), Metric (string) - possible metrics: Grams, Kilograms, Milliliters, Liters, Teaspoons, Tablespoons, Cups, Pieces)
+            Preparation Steps: (list of strings)
+            Duration: (string)
+            Number Of Portions: (integer)
+
+            If it is a recipe, convert it to a JSON using this example recipe as reference:
+            {
+              ""title"": ""Spaghetti Carbonara"",
+              ""description"": ""A classic Italian pasta dish made with eggs, cheese, pancetta, and pepper."",
+              ""ingredients"": [
+                {
+                  ""quantity"": ""200"",
+                  ""metric"": ""grams"",
+                  ""name"": ""spaghetti""
+                },
+                {
+                  ""quantity"": ""100"",
+                  ""metric"": ""grams"",
+                  ""name"": ""pancetta""
+                },
+                {
+                  ""quantity"": ""2"",
+                  ""metric"": ""pieces"",
+                  ""name"": ""eggs""
+                },
+                {
+                  ""quantity"": ""50"",
+                  ""metric"": ""grams"",
+                  ""name"": ""Parmesan cheese""
+                },
+                {
+                  ""quantity"": ""1"",
+                  ""metric"": ""teaspoon"",
+                  ""name"": ""black pepper""
+                },
+                {
+                  ""quantity"": ""1"",
+                  ""metric"": ""pinch"",
+                  ""name"": ""salt""
+                }
+              ],
+              ""preparationSteps"": [
+                ""Cook the spaghetti according to package instructions."",
+                ""In a pan, cook the pancetta until crispy."",
+                ""Beat the eggs in a bowl and mix in the grated Parmesan cheese."",
+                ""Drain the spaghetti and add it to the pan with the pancetta."",
+                ""Remove the pan from heat and quickly mix in the egg and cheese mixture."",
+                ""Season with black pepper and salt to taste."",
+                ""Serve immediately.""
+              ],
+              ""duration"": ""20 minutes"",
+              ""numberOfPortions"": 2
+            }
+            TEXT TO CONVERT:
+            ";
+
+
+
         public static string BuildSystemMessage(UserProfile profile)
         {
             var sb = new StringBuilder();
@@ -105,6 +170,15 @@ namespace CookingApp.Common.CompletionConstants
             sb.AppendLine(PromptEngineeringPrevention);
 
             return sb.ToString();
-        } 
+        }
+
+        public static string BuildRecipeConvertSystemMessage()
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine(PromptEngineeringPrevention);
+            sb.AppendLine(RecipeConverterPrompt);
+            return sb.ToString();
+        }
     }
 }

--- a/src/server/CookingApp/Common/CompletionConstants/Completions.cs
+++ b/src/server/CookingApp/Common/CompletionConstants/Completions.cs
@@ -9,20 +9,16 @@ namespace CookingApp.Common.CompletionConstants
             "You are a helpful assistant that answers questions related to cooking tips, recipes, kitchen tips." +
             "\n\rYou will receive queries containing different questions on cooking thematic or a list of products that you have to make use of and come up with a recipe for the user." +
             "\n\rYou need to take into account the user's dietary needs and their allergies so that you do not suggest a recipe that includes unhealthy or inappropriate contents.";
-        //public const string RecipeFormat = "When generating a recipe, provide it in a consistent JSON format following this structure: " +
-        //                "Title: (string), " +
-        //                "Description: (string), " +
-        //                "Ingredients: (list of objects with Name (string), Quantity (string), Metric (string) - possible metrics (USE THE EXACT STRINGS IN THEIR PLURAL FORMS): Grams, Kilograms, Milliliters, Liters, Teaspoons, Tablespoons, Cups, Pieces), " +
-        //                "PreparationSteps: (list of strings), " +
-        //                "Duration: (string), " +
-        //                "NumberOfPortions: (integer). " +
-        //                "Every recipe must be generated using this format. If a recipe is to be generated, send ONLY the recipe JSON without any other text. " +
-        //                "DO NOT use markdown or any environment new line separators such as (\\n). Send the JSON on a single line. If not asked to generate a recipe, respond with a completely regular answer.";
 
-
-
-
-
+        public const string RecipeFormat =
+            "When generating a recipe, provide it in a consistent format following this structure: " +
+            "Title: (string), " +
+            "Description: (string), " +
+            "Ingredients: (Name (string), Quantity (string), Metric (string) - possible metrics: Grams, Kilograms, Milliliters, Liters, Teaspoons, Tablespoons, Cups, Pieces), " +
+            "Preparation Steps: (list of strings), " +
+            "Duration: (string), " +
+            "Number Of Portions: (integer). ";
+        
 
         public const string AssistantCreateTitleInstructions = "Synthesize the information from the last messages to create a short title.";
 
@@ -87,9 +83,9 @@ namespace CookingApp.Common.CompletionConstants
             var sb = new StringBuilder();
 
             sb.AppendLine(AssistantInstructions);
-            //sb.AppendLine(RecipeFormat);
+            sb.AppendLine(RecipeFormat);
 
-            if(profile is not null) 
+            if (profile is not null) 
             {
                 if(profile.Allergies is not null)
                 {

--- a/src/server/CookingApp/Common/Helpers/Recipes/RecipeHelpers.cs
+++ b/src/server/CookingApp/Common/Helpers/Recipes/RecipeHelpers.cs
@@ -7,11 +7,24 @@ namespace CookingApp.Common.Helpers.Recipes
 {
     public class RecipeHelpers
     {
-        private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2); // Set the timeout to 2 seconds
+        private static readonly string[] RequiredSections =
+        [
+            "Title:",
+            "Description:",
+            "Ingredients:",
+            "Preparation Steps:",
+            "Duration:",
+            "Number Of Portions:"
+        ];
 
-        public static bool TryParseRecipe(string response, out Recipe recipe)
+        public static bool IsRecipe(string text)
         {
-            throw new NotImplementedException();
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            return RequiredSections.All(section => text.Contains(section, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/server/CookingApp/Controllers/ChatController.cs
+++ b/src/server/CookingApp/Controllers/ChatController.cs
@@ -1,4 +1,7 @@
-﻿namespace CookingApp.Controllers
+﻿using CookingApp.Models.Entities;
+using CookingApp.Services.Recipe;
+
+namespace CookingApp.Controllers
 {
     using CookingApp.Common.Helpers.Profiles;
     using CookingApp.Models;
@@ -12,6 +15,7 @@
 
     [ApiController]
     public class ChatController(IChatService chatService,
+        IRecipeService recipeService,
         IMessageService openAIService,
         IHttpContextAccessor httpContextAccessor) : ControllerBase
     {
@@ -27,6 +31,19 @@
                 Data = response
             };
         }
+        [HttpPost("convert")]
+        public async Task<IActionResult> ConvertRecipe([FromBody] string request)
+        {
+            var recipe = await recipeService.TryConvertToRecipe(request);
+
+            return new ApiResponse<Recipe>()
+            {
+                Status = 200,
+                Data = recipe
+            };
+        }
+
+
 
         [HttpGet("c/{chatId}")]
         public async Task<IActionResult> ChatById(string chatId)

--- a/src/server/CookingApp/Controllers/ChatController.cs
+++ b/src/server/CookingApp/Controllers/ChatController.cs
@@ -19,12 +19,12 @@
         public async Task<IActionResult> SendMessage([FromForm] MessageRequest message)
         {
             var userId = GetUser.ProfileId(httpContextAccessor);
-            var responce = await openAIService.SendMessage(userId, message);
+            var response = await openAIService.SendMessage(userId, message);
 
             return new ApiResponse<MessageResponse>()
             {
                 Status = 200,
-                Data = responce
+                Data = response
             };
         }
 

--- a/src/server/CookingApp/Controllers/ChatController.cs
+++ b/src/server/CookingApp/Controllers/ChatController.cs
@@ -15,7 +15,6 @@ namespace CookingApp.Controllers
 
     [ApiController]
     public class ChatController(IChatService chatService,
-        IRecipeService recipeService,
         IMessageService openAIService,
         IHttpContextAccessor httpContextAccessor) : ControllerBase
     {
@@ -31,19 +30,6 @@ namespace CookingApp.Controllers
                 Data = response
             };
         }
-        [HttpPost("convert")]
-        public async Task<IActionResult> ConvertRecipe([FromBody] string request)
-        {
-            var recipe = await recipeService.TryConvertToRecipe(request);
-
-            return new ApiResponse<Recipe>()
-            {
-                Status = 200,
-                Data = recipe
-            };
-        }
-
-
 
         [HttpGet("c/{chatId}")]
         public async Task<IActionResult> ChatById(string chatId)

--- a/src/server/CookingApp/Controllers/RecipeController.cs
+++ b/src/server/CookingApp/Controllers/RecipeController.cs
@@ -1,0 +1,33 @@
+﻿using CookingApp.Models.Entities;
+using CookingApp.Services.Recipe;
+using CookingApp.ViewModels.Api;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CookingApp.Controllers
+{
+    [ApiController]
+    public class RecipeController(IRecipeService recipeService) : ControllerBase
+    {
+        [HttpPost("create-recipe")]
+        public async Task<IActionResult> CreateRecipe([FromBody] string request)
+        {
+            var recipeId = await recipeService.CreateRecipe(request);
+
+            return new ApiResponse<string>()
+            {
+                Status = 200,
+                Data = recipeId
+            };
+        }
+
+        [HttpGet("r/{recipeId}")]
+        public async Task<IActionResult> RecipeById(string recipeId)
+        {
+            return new ApiResponse<Recipe>()
+            {
+                Status = 200,
+                Data = await recipeService.GetById(recipeId)
+            };
+        }
+    }
+}

--- a/src/server/CookingApp/CookingApp - Backup.csproj
+++ b/src/server/CookingApp/CookingApp - Backup.csproj
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>fb1ec677-510b-4f0c-aa70-c37734a288c6</UserSecretsId>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>.</DockerfileContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="ViewModels\Stripe\Product\**" />
+    <Content Remove="ViewModels\Stripe\Product\**" />
+    <EmbeddedResource Remove="ViewModels\Stripe\Product\**" />
+    <None Remove="ViewModels\Stripe\Product\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.19.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
+    <PackageReference Include="MongoDB.Bson" Version="2.25.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="OpenAI" Version="2.0.0-beta.7" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.1" />
+    <PackageReference Include="Stripe.net" Version="44.10.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Services\NewFolder\" />
+  </ItemGroup>
+
+</Project>

--- a/src/server/CookingApp/Infrastructure/Exceptions/InvalidRecipeRequestException.cs
+++ b/src/server/CookingApp/Infrastructure/Exceptions/InvalidRecipeRequestException.cs
@@ -1,0 +1,15 @@
+﻿namespace CookingApp.Infrastructure.Exceptions
+{
+    public class InvalidRecipeRequestException : Exception
+    {
+        public InvalidRecipeRequestException()
+        {
+
+        }
+
+        public InvalidRecipeRequestException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/src/server/CookingApp/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/CookingApp/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ using Newtonsoft.Json.Serialization;
 using OpenAI.Chat;
 using Stripe;
 using System.Diagnostics.CodeAnalysis;
+using CookingApp.Services.Recipe;
 
 namespace CookingApp.Infrastructure.Extensions
 {
@@ -184,6 +185,7 @@ namespace CookingApp.Infrastructure.Extensions
         {
             builder.Services.AddScoped<IStripeService, StripeService>();
             builder.Services.AddScoped<IUserProfileService, UserProfileService>();
+            builder.Services.AddScoped<IRecipeService, RecipeService>();
 
             return builder;
         }

--- a/src/server/CookingApp/Infrastructure/Middleware/ExceptionMiddleware.cs
+++ b/src/server/CookingApp/Infrastructure/Middleware/ExceptionMiddleware.cs
@@ -1,4 +1,6 @@
 ﻿
+using CookingApp.Infrastructure.Exceptions;
+
 namespace CookingApp.Infrastructure.Middleware
 {
     using CookingApp.ViewModels.Api;
@@ -27,6 +29,7 @@ namespace CookingApp.Infrastructure.Middleware
             {
                 ArgumentException => (int)HttpStatusCode.BadRequest,
                 StripeException => (int)HttpStatusCode.BadRequest,
+                InvalidRecipeRequestException => (int)HttpStatusCode.BadRequest,
                 _ => (int)HttpStatusCode.InternalServerError
             };
 

--- a/src/server/CookingApp/Models/Enums/MessageType.cs
+++ b/src/server/CookingApp/Models/Enums/MessageType.cs
@@ -4,6 +4,6 @@
     {
         Text,
         Image,
-        JSON
+        Recipe
     }
 }

--- a/src/server/CookingApp/Services/Message/MessageService.cs
+++ b/src/server/CookingApp/Services/Message/MessageService.cs
@@ -1,4 +1,6 @@
-﻿namespace CookingApp.Services.Message
+﻿using CookingApp.Common.Helpers.Recipes;
+
+namespace CookingApp.Services.Message
 {
     using CookingApp.Common.CompletionConstants;
     using CookingApp.Infrastructure.Interfaces;
@@ -80,7 +82,7 @@
             {
                 ChatId = chat.Id,
                 Content = response.Value.Content[0].Text,
-                Type = MessageType.Text
+                Type = RecipeHelpers.IsRecipe(response.Value.Content[0].Text) ? MessageType.Recipe : MessageType.Text 
             };
         }
 

--- a/src/server/CookingApp/Services/Recipe/IRecipeService.cs
+++ b/src/server/CookingApp/Services/Recipe/IRecipeService.cs
@@ -3,6 +3,20 @@
     using Models.Entities;
     public interface IRecipeService
     {
-        Task<Recipe?> TryConvertToRecipe(string request);
+        /// <summary>
+        /// Creates a new recipe from the given request string using OpenAI Chat to generate the recipe.
+        /// </summary>
+        /// <param name="request">The user input request string containing the recipe details.</param>
+        /// <returns>The ID of the newly created recipe.</returns>
+        /// <exception cref="InvalidRecipeRequestException">Thrown when the generated recipe is null or invalid.</exception>
+        Task<string> CreateRecipe(string request);
+
+        /// <summary>
+        /// Retrieves a recipe by its ID.
+        /// </summary>
+        /// <param name="recipeId">The ID of the recipe to retrieve.</param>
+        /// <returns>The Recipe entity matching the given ID.</returns>
+        /// <exception cref="NotFoundException">Thrown when no recipe is found with the given ID.</exception>
+        Task<Recipe> GetById(string recipeId);
     }
 }

--- a/src/server/CookingApp/Services/Recipe/IRecipeService.cs
+++ b/src/server/CookingApp/Services/Recipe/IRecipeService.cs
@@ -1,0 +1,8 @@
+﻿namespace CookingApp.Services.Recipe
+{
+    using Models.Entities;
+    public interface IRecipeService
+    {
+        Task<Recipe?> TryConvertToRecipe(string request);
+    }
+}

--- a/src/server/CookingApp/Services/Recipe/RecipeService.cs
+++ b/src/server/CookingApp/Services/Recipe/RecipeService.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using OpenAI.Chat;
+
+namespace CookingApp.Services.Recipe
+{
+    using CookingApp.Common.CompletionConstants;
+    using CookingApp.Models;
+    using Models.Entities;
+    public class RecipeService(ChatClient client) : IRecipeService
+    {
+        public async Task<Recipe?> TryConvertToRecipe(string request)
+        {
+            var messages = new List<ChatMessage>
+            {
+                new SystemChatMessage(Completions.BuildRecipeConvertSystemMessage())
+            };
+            messages.Add(new UserChatMessage(request));
+            var chatOpts = new ChatCompletionOptions()
+            {
+                ResponseFormat = ChatResponseFormat.JsonObject
+            };
+            var response = await client.CompleteChatAsync(messages, chatOpts);
+            var recipe = JsonConvert.DeserializeObject<Recipe>(response.Value.Content[0].Text);
+
+            return recipe;
+        }
+    }
+}


### PR DESCRIPTION
Endpoints:

    Create Recipe
        Route: POST /create-recipe
        Request Body: A string containing the recipe details.
        Response: Returns a JSON response containing the ID of the newly created recipe.
        Implementation: Utilizes the IRecipeService to generate a recipe using OpenAI Chat and save it to the repository.

    Get Recipe by ID
        Route: GET /r/{recipeId}
        Parameters: recipeId - The ID of the recipe to retrieve.
        Response: Returns a JSON response containing the recipe entity corresponding to the given ID.
        Implementation: Utilizes the IRecipeService to fetch the recipe details from the repository.
        
All responses returned by the /message endpoint are checked for recipe characteristics and if they match the response type will be Recipe. This should enable FE functionality for a convert to recipe button that sends chatgpts response back to the server for so it can be converted to a recipe.

Closes #77
  